### PR TITLE
updates VSCode settings and recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,8 @@
 {
     "recommendations": [
+        "DavidAnson.vscode-markdownlint",
+        "dbaeumer.vscode-eslint",
         "ms-vscode.vscode-typescript-next",
-        "yoavbls.pretty-ts-errors",
-        "dbaeumer.vscode-eslint"
+        "yoavbls.pretty-ts-errors"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,9 @@
         },
         "editor.defaultFormatter": "vscode.typescript-language-features"
     },
+    "markdownlint.customRules": [
+        "MD041"
+    ],
     "[json]": {
         "editor.codeActionsOnSave": {
             "source.fixAll": "explicit",


### PR DESCRIPTION
adds `markdownlint` settings to ignore `md041/first-line-heading` warnings and includes MDL in the recommended vsc extensions list.